### PR TITLE
USE CCI/BCC (copie carbone invisible) to send the newsletter

### DIFF
--- a/lib/Service/NewsletterService.php
+++ b/lib/Service/NewsletterService.php
@@ -109,7 +109,7 @@ class NewsletterService {
         $config = $this->configService->load();
         $template = $this->buildTemplate($config);
         $msg = $this->mailer->createMessage();
-        $msg->setTo($recipients);
+        $msg->setBcc($recipients);
         $msg->setPlainBody($template->renderText());
         $msg->setHtmlBody($template->renderHtml());
         $msg->setSubject($subject);


### PR DESCRIPTION
Send the newsletter privately.
This do not expose recipients each other.
Use CCI/BCC field to send email, not the A (TO) field.

FIX issue https://github.com/mziech/nextcloud-calendar-news/issues/14